### PR TITLE
Seperate travis-ci into two seperate builds (#6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,19 @@ jdk:
 language: node_js
 node_js:
 - lts/*
-script:
-- (cd minsky-gatsby && yarn install && yarn build) 
-- (cd minsky-one && mvn package; export MAVEN_RESULT=$?)
-- if [ "$MAVEN_RESULT" -ne 0 ]; then exit 1; fi
+
+jobs:
+  include:
+    - stage: gatsby-frontend
+      script:
+      - cd minsky-gatsby
+      - yarn install 
+      - yarn build
+    - stage: java-backend
+      script: 
+      - (cd minsky-one && mvn package; export MAVEN_RESULT=$?)
+      - if [ "$MAVEN_RESULT" -ne 0 ]; then exit 1; fi
+
 before_deploy:
 - export TAGNAME=`git describe --tags --abbrev=0`
 - deploy-scripts/before-deploy.sh
@@ -21,5 +30,6 @@ deploy:
   skip_cleanup: true
   draft: false
   on:
-    repo: ECM3432-A/ECM3432-2021-minsky
+    repo: ExeterBScDTS/ECM3432-2021-minsky
     tags: true
+


### PR DESCRIPTION
* Seperate travis-ci into two stages: Attempt #1

* Attempt 2

* Attempt 3

* fix yaml

* Clean dependencies

* Revert "fix yaml"

This reverts commit d2753984352ee5e51d7193d684ba165066ff7ee3.

* oops

Co-authored-by: Austen Tulodziecki <Austen.Tulodziecki@renishaw.com>